### PR TITLE
Change Application.cfc method "onApplicationStop" to "onApplicationEnd" in examples

### DIFF
--- a/AbstractExecutorService.cfc
+++ b/AbstractExecutorService.cfc
@@ -11,7 +11,7 @@ component output="false" accessors="true"{
 	/*
 		storage scope is a server-scoped bucket into which we put "things that can shut down";
 		we need this as a safeguard against developers who don't heed instructions to *ensure* that
-		stop() is called onApplicationStop().
+		stop() is called in onApplicationEnd().
 
 		Any executors we create will live in this scope, and on initialization, any previously created
 		executors will be shutdown immediately and then removed from scope

--- a/Application.cfc
+++ b/Application.cfc
@@ -9,12 +9,10 @@ component{
 	function onRequestStart(){
 		if( structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
-
 		}
 	}
 
-	function onApplicationStop(){
+	function onApplicationEnd(required struct applicationScope){
 	}
-
+	
 }

--- a/examples/CancellingTasks/Application.cfc
+++ b/examples/CancellingTasks/Application.cfc
@@ -13,7 +13,6 @@ component extends="cfconcurrent.Application"{
 	function onRequestStart(){
 		if( structKeyExists(url, "stop") OR structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
 		}
 
 		if( structKeyExists(url, "reinit") ){
@@ -21,8 +20,10 @@ component extends="cfconcurrent.Application"{
 		}
 	}
 
-	function onApplicationStop(){
-		application.executorService.stop();
+	function onApplicationEnd(required struct applicationScope){
+		if (structKeyExists(arguments.applicationScope, "executorService")) {
+			arguments.applicationScope.executorService.stop();
+		}
 	}
 
 }

--- a/examples/CancellingTasks/index.cfm
+++ b/examples/CancellingTasks/index.cfm
@@ -64,7 +64,7 @@
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/CancellingTasks/submit.cfm
+++ b/examples/CancellingTasks/submit.cfm
@@ -57,7 +57,7 @@ try{
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ExecutorCompletionService/Application.cfc
+++ b/examples/ExecutorCompletionService/Application.cfc
@@ -20,7 +20,6 @@ component extends="cfconcurrent.Application"{
 	function onRequestStart(){
 		if( structKeyExists(url, "stop") OR structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
 		}
 
 		if( structKeyExists(url, "reinit") ){
@@ -28,9 +27,11 @@ component extends="cfconcurrent.Application"{
 		}
 	}
 
-	function onApplicationStop(){
-		writeLog("Stopping #application.applicationName# Completion Service");
-		application.executorCompletionService.stop(timeout=5000);
+	function onApplicationEnd(required struct applicationScope){
+		if (structKeyExists(arguments.applicationScope, "executorCompletionService")) {
+			writeLog("Stopping #application.applicationName# Completion Service");
+			arguments.applicationScope.executorCompletionService.stop(timeout=5000);
+		}
 	}
 
 }

--- a/examples/ExecutorCompletionService/index.cfm
+++ b/examples/ExecutorCompletionService/index.cfm
@@ -49,7 +49,7 @@
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ExecutorCompletionService/submit.cfm
+++ b/examples/ExecutorCompletionService/submit.cfm
@@ -53,7 +53,7 @@
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor (and start a new one) onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor (and start a new one) onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ExecutorService/Application.cfc
+++ b/examples/ExecutorService/Application.cfc
@@ -13,7 +13,6 @@ component extends="cfconcurrent.Application"{
 	function onRequestStart(){
 		if( structKeyExists(url, "stop") OR structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
 		}
 
 		if( structKeyExists(url, "reinit") ){
@@ -21,8 +20,10 @@ component extends="cfconcurrent.Application"{
 		}
 	}
 
-	function onApplicationStop(){
-		application.executorService.stop();
+	function onApplicationEnd(required struct applicationScope){
+		if (structKeyExists(arguments.applicationScope, "executorService")) {
+			arguments.applicationScope.executorService.stop();
+		}
 	}
 
 }

--- a/examples/ExecutorService/index.cfm
+++ b/examples/ExecutorService/index.cfm
@@ -64,7 +64,7 @@
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ExecutorService/submit.cfm
+++ b/examples/ExecutorService/submit.cfm
@@ -103,7 +103,7 @@ for( future in futures ){
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ScheduledThreadPoolExecutor/Application.cfc
+++ b/examples/ScheduledThreadPoolExecutor/Application.cfc
@@ -17,7 +17,6 @@ component extends="cfconcurrent.Application"{
 	function onRequestStart(){
 		if( structKeyExists(url, "stop") OR structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
 		}
 
 		if( structKeyExists(url, "reinit") ){
@@ -25,8 +24,10 @@ component extends="cfconcurrent.Application"{
 		}
 	}
 
-	function onApplicationStop(){
-		application.executorService.stop();
+	function onApplicationEnd(required struct applicationScope){
+		if (structKeyExists(arguments.applicationScope, "executorService")) {
+			arguments.applicationScope.executorService.stop();
+		}
 	}
 
 }

--- a/examples/ScheduledThreadPoolExecutor/index.cfm
+++ b/examples/ScheduledThreadPoolExecutor/index.cfm
@@ -53,7 +53,7 @@
 	      <h2>Stop or Re-init the app</h2>
 	      <p><a href="index.cfm?stop">Stop the app</a></p>
 	      <p><a href="index.cfm?reinit">Reinit the app</a></p>
-		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationStop()... Read that code. You <b>must</b> do this in your own code!</p>
+		  <p><b>Note: </b> Application.cfc will shut down the executor onApplicationEnd()... Read that code. You <b>must</b> do this in your own code!</p>
 	    </div><!--/span-->
 
 	  </div><!--/row-->

--- a/examples/ormInExecutor/Application.cfc
+++ b/examples/ormInExecutor/Application.cfc
@@ -18,7 +18,6 @@ component extends="cfconcurrent.Application"{
 	function onRequestStart(){
 		if( structKeyExists(url, "stop") OR structKeyExists(url, "reinit") ){
 			applicationStop();
-			onApplicationStop();
 		}
 		
 		if( structKeyExists(url, "reinit") ){
@@ -26,8 +25,10 @@ component extends="cfconcurrent.Application"{
 		}
 	}
 
-	function onApplicationStop(){
-		application.executorCompletionService.stop();
+	function onApplicationEnd(required struct applicationScope){
+		if (structKeyExists(arguments.applicationScope, "executorCompletionService")) {
+			arguments.applicationScope.executorCompletionService.stop();
+		}
 	}
 
 }


### PR DESCRIPTION
The ACF/Railo/Lucee internal Application.cfc function is called onApplicationEnd instead of onApplicationStop. I suggest to use it.
This way there are also no errors if calling the method manually after applicationStop() during a re-init or manual stop of the example apps. There is no manual call of the method required.

Reference: https://wikidocs.adobe.com/wiki/display/coldfusionen/onApplicationEnd
